### PR TITLE
Stable/kilo

### DIFF
--- a/neutron/ipam/drivers/infoblox/dns_controller.py
+++ b/neutron/ipam/drivers/infoblox/dns_controller.py
@@ -236,7 +236,8 @@ class InfobloxDNSController(neutron_ipam.NeutronDNSController):
         #       in the network.
         # Reverse zone is deleted when not global, not external, and not shared
         if neutron_conf.CONF.allow_admin_network_deletion or \
-                not (cfg.is_global_config or is_external or is_shared):
+                not (cfg.is_global_config or is_external or is_shared or
+                     neutron_conf.CONF.subnet_shared_for_deletion):
             if (('{subnet_name}' in cfg.domain_suffix_pattern or
                     '{subnet_id}' in cfg.domain_suffix_pattern) or
                 (('{network_name}' in cfg.domain_suffix_pattern or

--- a/neutron/ipam/drivers/infoblox/tasks.py
+++ b/neutron/ipam/drivers/infoblox/tasks.py
@@ -17,7 +17,7 @@ import operator
 from taskflow import task
 
 from neutron.ipam.drivers.infoblox import exceptions
-
+from oslo.config import cfg as neutron_conf
 
 class CreateNetViewTask(task.Task):
     def execute(self, obj_manip, net_view_name, nview_extattrs, dhcp_member):
@@ -52,7 +52,7 @@ class ChainInfobloxNetworkTask(task.Task):
         eas = operator.itemgetter(*ea_names)(network_extattrs)
         shared_or_external = any(eval(ea['value']) for ea in eas)
 
-        if shared_or_external:
+        if shared_or_external or neutron_conf.CONF.subnet_shared_for_creation:
             ib_network = obj_manip.get_network(net_view_name, cidr)
             obj_manip.update_network_options(ib_network, network_extattrs)
         else:


### PR DESCRIPTION
Added configuration that indicates whether all subnest are shared for creation and/or deletion.

"neutron.conf"
subnet_shared_for_creation = false
subnet_shared_for_deletion = false
